### PR TITLE
fix(vimenv): repair off by one error in lines_following_cursor

### DIFF
--- a/python/vimenv.py
+++ b/python/vimenv.py
@@ -102,7 +102,7 @@ class VimEnviroment(Enviroment):
         cursor_row = vim.current.window.cursor[0] - 1
         current_row = cursor_row
         while True:
-            if current_row >= len(vim.current.buffer) - 1:
+            if current_row > len(vim.current.buffer) - 1:
                 raise StopIteration('Buffer is out of lines.')
             yield current_row, buffer[current_row]
             current_row += 1


### PR DESCRIPTION
## Summary

The greater than OR equal meant that the generator wasn't reading the last line of the file.

Closes #3 