### PR TITLE
fix class assign visitor. visit targets instead of the node

### DIFF
--- a/python/asthelper.py
+++ b/python/asthelper.py
@@ -52,7 +52,7 @@ class ClassVisitor(ast.NodeVisitor):
     def visit_Assign(self, node):
         ac = AttributeCollector(self.instance_name)
         for target in node.targets:
-            ac.visit(node)
+            ac.visit(target)
         self.attributes |= ac.data
 
 


### PR DESCRIPTION
```
class Test:
    def aaa(self):
        pass

    def bbb(self):
        x = self.aaa()
```

currently `aaa` is picked up as an attribute though it shouldn't. the suggested change helps to avoid this.