### PR TITLE
allow annassigns for instance variables of a class

### DIFF
--- a/python/asthelper.py
+++ b/python/asthelper.py
@@ -55,6 +55,11 @@ class ClassVisitor(ast.NodeVisitor):
             ac.visit(node)
         self.attributes |= ac.data
 
+    def visit_AnnAssign(self, node):
+        ac = AttributeCollector(self.instance_name)
+        ac.visit(node.target)
+        self.attributes |= ac.data
+
 
 class MethodVisitor(ast.NodeVisitor):
     """Gathers information about a method


### PR DESCRIPTION
Support these:

```
class Test:
    def __init__(self, n):
        self.n: int = n
```

in future maybe also allow type annotations for the attributes of the class to be included into the docstring. but at least to pick up the assignments would be already very helpful :)