### PR TITLE
Improve error handling

### DIFF
--- a/autoload/vimpythondocstring.vim
+++ b/autoload/vimpythondocstring.vim
@@ -12,14 +12,32 @@ sys.path[0:0] = deps
 import pydocstring
 EOF
 
+function! s:handle_error(exception)
+    echohl ErrorMsg
+    echo join(map(split(a:exception, ":")[2:], 'trim(v:val)'), " : ")
+    echohl None
+endfunction
+
 function! vimpythondocstring#Full()
-    python3 pydocstring.Docstring().full_docstring()
+    try
+        python3 pydocstring.Docstring().full_docstring()
+    catch
+        call s:handle_error(v:exception)
+    endtry
 endfunction
 
 function! vimpythondocstring#FullTypes()
-    python3 pydocstring.Docstring().full_docstring(print_hints=True)
+    try
+        python3 pydocstring.Docstring().full_docstring(print_hints=True)
+    catch
+        call s:handle_error(v:exception)
+    endtry
 endfunction
 
 function! vimpythondocstring#Oneline()
-    python3 pydocstring.Docstring().oneline_docstring()
+    try
+        python3 pydocstring.Docstring().oneline_docstring()
+    catch
+        call s:handle_error(v:exception)
+    endtry
 endfunction

--- a/python/pydocstring.py
+++ b/python/pydocstring.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-from string import Template
-import re
-import os
-import ast
 import abc
+import ast
+import os
+import re
+from string import Template
 
 import ibis
-
+from asthelper import ClassInstanceNameExtractor, ClassVisitor, MethodVisitor
 from utils import *
 from vimenv import *
-from asthelper import ClassVisitor, MethodVisitor, ClassInstanceNameExtractor
 
 
 class InvalidSyntax(Exception):
@@ -256,7 +255,10 @@ class Docstring:
 
     def _controller_factory(self, env, templater):
         line = env.current_line
-        first_word = re.match(r"^\s*(\w+).*", line).groups()[0]
+        try:
+            first_word = re.match(r"^\s*(\w+).*", line).groups()[0]
+        except Exception:
+            first_word = None
         if first_word == "def":
             return MethodController(env, templater)
         elif first_word == "class":
@@ -268,18 +270,18 @@ class Docstring:
                 if second_word == "def":
                     return MethodController(env, templater)
 
-        raise DocstringUnavailable("Docstring cannot be created for selected object")
+        raise DocstringUnavailable("Docstring ERROR: Doctring cannot be created for selected object")
 
     def full_docstring(self, print_hints=False):
         """Writes docstring containing arguments, returns, raises, ..."""
         try:
             self.obj_controller.write_docstring(print_hints=print_hints)
         except Exception as e:
-            print(concat_("Doctring ERROR: ", e))
+            raise DocstringUnavailable(concat_("Docstring ERROR: ", e))
 
     def oneline_docstring(self):
         """Writes only a one-line empty docstring"""
         try:
             self.obj_controller.write_simple_docstring()
         except Exception as e:
-            print(concat_("Doctring ERROR: ", e))
+            raise DocstringUnavailable(concat_("Docstring ERROR: ", e))


### PR DESCRIPTION
Closes #36 

This PR just improves how errors are reported.

If you try to generate a docstring for an invalid line under the cursor it will output the following:

![Screenshot from 2023-02-27 11-13-27](https://user-images.githubusercontent.com/22531177/221549383-bedef392-f288-4344-b0b7-7adc462a0df1.png)

Instead of:

![Screenshot from 2023-02-27 11-12-17](https://user-images.githubusercontent.com/22531177/221549400-be98f943-7806-4b86-9628-fe24fe2a47a6.png)
